### PR TITLE
Allow the authorization header name to vary

### DIFF
--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -5,11 +5,12 @@ class GraphQLClient:
     def __init__(self, endpoint):
         self.endpoint = endpoint
         self.token = None
+        self.headername = None
 
     def execute(self, query, variables=None):
         return self._send(query, variables)
 
-    def inject_token(self, token):
+    def inject_token(self, token, headername='Authorization'):
         self.token = token
 
     def _send(self, query, variables):
@@ -19,7 +20,7 @@ class GraphQLClient:
                    'Content-Type': 'application/json'}
 
         if self.token is not None:
-            headers['Authorization'] = '{}'.format(self.token)
+            headers[self.headername] = '{}'.format(self.token)
 
         req = urllib.request.Request(self.endpoint, json.dumps(data).encode('utf-8'), headers)
 

--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -12,6 +12,7 @@ class GraphQLClient:
 
     def inject_token(self, token, headername='Authorization'):
         self.token = token
+        self.headername = headername
 
     def _send(self, query, variables):
         data = {'query': query,


### PR DESCRIPTION
AWS AppSync uses x-api-key instead of Authorization, so I have a need to vary this. I've left it in such a way that 'Authorization' is the default if not specified, to keep this change backwards compatible.