### PR TITLE
feat: replace print with log

### DIFF
--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -1,5 +1,6 @@
 from six.moves import urllib
 import json
+import logging
 
 class GraphQLClient:
     def __init__(self, endpoint):
@@ -29,6 +30,5 @@ class GraphQLClient:
             response = urllib.request.urlopen(req)
             return response.read().decode('utf-8')
         except urllib.error.HTTPError as e:
-            print((e.read()))
-            print('')
+            logging.debug((e.read()))
             raise e


### PR DESCRIPTION
when using this client externally, the user sometimes does not want the response to be printed out.

this PR replaces the print statements with logging.debug statements.
if you think this change makes sense but want more flexibility around the log level, i'm willing to extend this PR as well.

thanks a lot!