### PR TITLE
Simplified GraphQLClient

### DIFF
--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -1,34 +1,13 @@
-from six.moves import urllib
-import json
-
 class GraphQLClient:
     def __init__(self, endpoint):
         self.endpoint = endpoint
-        self.token = None
-        self.headername = None
+        self.headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
 
     def execute(self, query, variables=None):
-        return self._send(query, variables)
+        return post(self.endpoint, json=dict(query=query, variables=variables), headers=self.headers).json()
 
-    def inject_token(self, token, headername='Authorization'):
-        self.token = token
-        self.headername = headername
-
-    def _send(self, query, variables):
-        data = {'query': query,
-                'variables': variables}
-        headers = {'Accept': 'application/json',
-                   'Content-Type': 'application/json'}
-
-        if self.token is not None:
-            headers[self.headername] = '{}'.format(self.token)
-
-        req = urllib.request.Request(self.endpoint, json.dumps(data).encode('utf-8'), headers)
-
-        try:
-            response = urllib.request.urlopen(req)
-            return response.read().decode('utf-8')
-        except urllib.error.HTTPError as e:
-            print((e.read()))
-            print('')
-            raise e
+    def add_header(self, name, value):
+        self.headers[name] = value


### PR DESCRIPTION
Changes made:
- Using `requests` instead of `urllib`
- Letting exceptions propagate to caller instead of catching and rethrowing
- Added generic header injection
- Deserialize JSON into dict for easier processing