### PR TITLE
feat: Add parameter to allow error printing suppression

### DIFF
--- a/graphqlclient/client.py
+++ b/graphqlclient/client.py
@@ -14,7 +14,7 @@ class GraphQLClient:
         self.token = token
         self.headername = headername
 
-    def _send(self, query, variables):
+    def _send(self, query, variables, print_err=True):
         data = {'query': query,
                 'variables': variables}
         headers = {'Accept': 'application/json',
@@ -29,6 +29,7 @@ class GraphQLClient:
             response = urllib.request.urlopen(req)
             return response.read().decode('utf-8')
         except urllib.error.HTTPError as e:
-            print((e.read()))
-            print('')
+            if print_err is True:
+                print((e.read()))
+                print('')
             raise e


### PR DESCRIPTION
Allow for `_send` to fail silently without printing the error message. Often it is useful to handle (and print) the error outside the `_send` function. This commit adds a `print_err` argument (defaults to True), so to suppress the error printing one can simply set this to False.

This should be especially useful if more sophisticated error handling and logging is implemented to customize the errors without having prints that are neither formatted nor have any debug level associated to it.